### PR TITLE
Add "list" and "watch" verbs to ClusterRole

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -18,7 +18,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["aws.k8s.logmein.com"]
   resources: ["eips", "enis"]
   verbs: ["*"]


### PR DESCRIPTION
The "list" and "watch" verbs were required by the Cluster Role when deploying k8s-aws-operator. Otherwise, the following errors were seen:

`k8s-aws-operator-55c754f6d4-pp9pd k8s-aws-operator E0112 15:23:23.824414       1 reflector.go:382] pkg/mod/k8s.io/client-go@v0.18.2/tools/cache/reflector.go:125: Failed to watch *v1.Pod: unknown (get pods)`

`k8s-aws-operator-55c754f6d4-pp9pd k8s-aws-operator E0111 22:48:07.206323       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.2/tools/cache/reflector.go:125: Failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:kube-system:k8s-aws-operator" cannot list resource "pods" in API group "" at the cluster scope`