### PR TITLE
feat: add pod controller to trigger EIP reconciles on pod replacement

### DIFF
--- a/api/v1alpha1/eip_types.go
+++ b/api/v1alpha1/eip_types.go
@@ -17,6 +17,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type EIPAssignment struct {
@@ -68,6 +69,7 @@ type EIPStatus struct {
 
 	AssociationId string         `json:"associationId,omitempty"`
 	Assignment    *EIPAssignment `json:"assignment,omitempty"`
+	PodUID        types.UID      `json:"podUUID,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/aws.k8s.logmein.com_eips.yaml
+++ b/config/crd/bases/aws.k8s.logmein.com_eips.yaml
@@ -3,6 +3,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: eips.aws.k8s.logmein.com
 spec:
@@ -25,8 +27,10 @@ spec:
   group: aws.k8s.logmein.com
   names:
     kind: EIP
+    listKind: EIPList
     plural: eips
-  scope: ""
+    singular: eip
+  scope: Namespaced
   subresources: {}
   validation:
     openAPIV3Schema:
@@ -35,372 +39,17 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
-          properties:
-            annotations:
-              additionalProperties:
-                type: string
-              description: 'Annotations is an unstructured key value map stored with
-                a resource that may be set by external tools to store and retrieve
-                arbitrary metadata. They are not queryable and should be preserved
-                when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
-              type: object
-            clusterName:
-              description: The name of the cluster which the object belongs to. This
-                is used to distinguish resources with same name and namespace in different
-                clusters. This field is not set anywhere right now and apiserver is
-                going to ignore it if set in create or update request.
-              type: string
-            creationTimestamp:
-              description: "CreationTimestamp is a timestamp representing the server
-                time when this object was created. It is not guaranteed to be set
-                in happens-before order across separate operations. Clients may not
-                set this value. It is represented in RFC3339 form and is in UTC. \n
-                Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-              format: date-time
-              type: string
-            deletionGracePeriodSeconds:
-              description: Number of seconds allowed for this object to gracefully
-                terminate before it will be removed from the system. Only set when
-                deletionTimestamp is also set. May only be shortened. Read-only.
-              format: int64
-              type: integer
-            deletionTimestamp:
-              description: "DeletionTimestamp is RFC 3339 date and time at which this
-                resource will be deleted. This field is set by the server when a graceful
-                deletion is requested by the user, and is not directly settable by
-                a client. The resource is expected to be deleted (no longer visible
-                from resource lists, and not reachable by name) after the time in
-                this field, once the finalizers list is empty. As long as the finalizers
-                list contains items, deletion is blocked. Once the deletionTimestamp
-                is set, this value may not be unset or be set further into the future,
-                although it may be shortened or the resource may be deleted prior
-                to this time. For example, a user may request that a pod is deleted
-                in 30 seconds. The Kubelet will react by sending a graceful termination
-                signal to the containers in the pod. After that 30 seconds, the Kubelet
-                will send a hard termination signal (SIGKILL) to the container and
-                after cleanup, remove the pod from the API. In the presence of network
-                partitions, this object may still exist after this timestamp, until
-                an administrator or automated process can determine the resource is
-                fully terminated. If not set, graceful deletion of the object has
-                not been requested. \n Populated by the system when a graceful deletion
-                is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-              format: date-time
-              type: string
-            finalizers:
-              description: Must be empty before the object is deleted from the registry.
-                Each entry is an identifier for the responsible component that will
-                remove the entry from the list. If the deletionTimestamp of the object
-                is non-nil, entries in this list can only be removed.
-              items:
-                type: string
-              type: array
-            generateName:
-              description: "GenerateName is an optional prefix, used by the server,
-                to generate a unique name ONLY IF the Name field has not been provided.
-                If this field is used, the name returned to the client will be different
-                than the name passed. This value will also be combined with a unique
-                suffix. The provided value has the same validation rules as the Name
-                field, and may be truncated by the length of the suffix required to
-                make the value unique on the server. \n If this field is specified
-                and the generated name exists, the server will NOT return a 409 -
-                instead, it will either return 201 Created or 500 with Reason ServerTimeout
-                indicating a unique name could not be found in the time allotted,
-                and the client should retry (optionally after the time indicated in
-                the Retry-After header). \n Applied only if Name is not specified.
-                More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency"
-              type: string
-            generation:
-              description: A sequence number representing a specific generation of
-                the desired state. Populated by the system. Read-only.
-              format: int64
-              type: integer
-            initializers:
-              description: "An initializer is a controller which enforces some system
-                invariant at object creation time. This field is a list of initializers
-                that have not yet acted on this object. If nil or empty, this object
-                has been completely initialized. Otherwise, the object is considered
-                uninitialized and is hidden (in list/watch and get calls) from clients
-                that haven't explicitly asked to observe uninitialized objects. \n
-                When an object is created, the system will populate this list with
-                the current set of initializers. Only privileged users may set or
-                modify this list. Once it is empty, it may not be modified further
-                by any user. \n DEPRECATED - initializers are an alpha field and will
-                be removed in v1.15."
-              properties:
-                pending:
-                  description: Pending is a list of initializers that must execute
-                    in order before this object is visible. When the last pending
-                    initializer is removed, and no failing result is set, the initializers
-                    struct will be set to nil and the object is considered as initialized
-                    and visible to all clients.
-                  items:
-                    properties:
-                      name:
-                        description: name of the process that is responsible for initializing
-                          this object.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  type: array
-                result:
-                  description: If result is set with the Failure field, the object
-                    will be persisted to storage and then deleted, ensuring that other
-                    clients can observe the deletion.
-                  properties:
-                    apiVersion:
-                      description: 'APIVersion defines the versioned schema of this
-                        representation of an object. Servers should convert recognized
-                        schemas to the latest internal value, and may reject unrecognized
-                        values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-                      type: string
-                    code:
-                      description: Suggested HTTP return code for this status, 0 if
-                        not set.
-                      format: int32
-                      type: integer
-                    details:
-                      description: Extended data associated with the reason.  Each
-                        reason may define its own extended details. This field is
-                        optional and the data returned is not guaranteed to conform
-                        to any schema except that defined by the reason type.
-                      properties:
-                        causes:
-                          description: The Causes array includes more details associated
-                            with the StatusReason failure. Not all StatusReasons may
-                            provide detailed causes.
-                          items:
-                            properties:
-                              field:
-                                description: "The field of the resource that has caused
-                                  this error, as named by its JSON serialization.
-                                  May include dot and postfix notation for nested
-                                  attributes. Arrays are zero-indexed.  Fields may
-                                  appear more than once in an array of causes due
-                                  to fields having multiple errors. Optional. \n Examples:
-                                  \  \"name\" - the field \"name\" on the current
-                                  resource   \"items[0].name\" - the field \"name\"
-                                  on the first array entry in \"items\""
-                                type: string
-                              message:
-                                description: A human-readable description of the cause
-                                  of the error.  This field may be presented as-is
-                                  to a reader.
-                                type: string
-                              reason:
-                                description: A machine-readable description of the
-                                  cause of the error. If this value is empty there
-                                  is no information available.
-                                type: string
-                            type: object
-                          type: array
-                        group:
-                          description: The group attribute of the resource associated
-                            with the status StatusReason.
-                          type: string
-                        kind:
-                          description: 'The kind attribute of the resource associated
-                            with the status StatusReason. On some operations may differ
-                            from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-                          type: string
-                        name:
-                          description: The name attribute of the resource associated
-                            with the status StatusReason (when there is a single name
-                            which can be described).
-                          type: string
-                        retryAfterSeconds:
-                          description: If specified, the time in seconds before the
-                            operation should be retried. Some errors may indicate
-                            the client must take an alternate action - for those errors
-                            this field may indicate how long to wait before taking
-                            the alternate action.
-                          format: int32
-                          type: integer
-                        uid:
-                          description: 'UID of the resource. (when there is a single
-                            resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
-                          type: string
-                      type: object
-                    kind:
-                      description: 'Kind is a string value representing the REST resource
-                        this object represents. Servers may infer this from the endpoint
-                        the client submits requests to. Cannot be updated. In CamelCase.
-                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-                      type: string
-                    message:
-                      description: A human-readable description of the status of this
-                        operation.
-                      type: string
-                    metadata:
-                      description: 'Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-                      properties:
-                        continue:
-                          description: continue may be set if the user set a limit
-                            on the number of items returned, and indicates that the
-                            server has more data available. The value is opaque and
-                            may be used to issue another request to the endpoint that
-                            served this list to retrieve the next set of available
-                            objects. Continuing a consistent list may not be possible
-                            if the server configuration has changed or more than a
-                            few minutes have passed. The resourceVersion field returned
-                            when using this continue value will be identical to the
-                            value in the first response, unless you have received
-                            this token from an error message.
-                          type: string
-                        resourceVersion:
-                          description: 'String that identifies the server''s internal
-                            version of this object that can be used by clients to
-                            determine when objects have changed. Value must be treated
-                            as opaque by clients and passed unmodified back to the
-                            server. Populated by the system. Read-only. More info:
-                            https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
-                          type: string
-                        selfLink:
-                          description: selfLink is a URL representing this object.
-                            Populated by the system. Read-only.
-                          type: string
-                      type: object
-                    reason:
-                      description: A machine-readable description of why this operation
-                        is in the "Failure" status. If this value is empty there is
-                        no information available. A Reason clarifies an HTTP status
-                        code but does not override it.
-                      type: string
-                    status:
-                      description: 'Status of the operation. One of: "Success" or
-                        "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
-                      type: string
-                  type: object
-              required:
-              - pending
-              type: object
-            labels:
-              additionalProperties:
-                type: string
-              description: 'Map of string keys and values that can be used to organize
-                and categorize (scope and select) objects. May match selectors of
-                replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
-              type: object
-            managedFields:
-              description: "ManagedFields maps workflow-id and version to the set
-                of fields that are managed by that workflow. This is mostly for internal
-                housekeeping, and users typically shouldn't need to set or understand
-                this field. A workflow can be the user's name, a controller's name,
-                or the name of a specific apply path like \"ci-cd\". The set of fields
-                is always in the version that the workflow used when modifying the
-                object. \n This field is alpha and can be changed or removed without
-                notice."
-              items:
-                properties:
-                  apiVersion:
-                    description: APIVersion defines the version of this resource that
-                      this field set applies to. The format is "group/version" just
-                      like the top-level APIVersion field. It is necessary to track
-                      the version of a field set because it cannot be automatically
-                      converted.
-                    type: string
-                  fields:
-                    additionalProperties: true
-                    description: Fields identifies a set of fields.
-                    type: object
-                  manager:
-                    description: Manager is an identifier of the workflow managing
-                      these fields.
-                    type: string
-                  operation:
-                    description: Operation is the type of operation which lead to
-                      this ManagedFieldsEntry being created. The only valid values
-                      for this field are 'Apply' and 'Update'.
-                    type: string
-                  time:
-                    description: Time is timestamp of when these fields were set.
-                      It should always be empty if Operation is 'Apply'
-                    format: date-time
-                    type: string
-                type: object
-              type: array
-            name:
-              description: 'Name must be unique within a namespace. Is required when
-                creating resources, although some resources may allow a client to
-                request the generation of an appropriate name automatically. Name
-                is primarily intended for creation idempotence and configuration definition.
-                Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-              type: string
-            namespace:
-              description: "Namespace defines the space within each name must be unique.
-                An empty namespace is equivalent to the \"default\" namespace, but
-                \"default\" is the canonical representation. Not all objects are required
-                to be scoped to a namespace - the value of this field for those objects
-                will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info:
-                http://kubernetes.io/docs/user-guide/namespaces"
-              type: string
-            ownerReferences:
-              description: List of objects depended by this object. If ALL objects
-                in the list have been deleted, this object will be garbage collected.
-                If this object is managed by a controller, then an entry in this list
-                will point to this controller, with the controller field set to true.
-                There cannot be more than one managing controller.
-              items:
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  blockOwnerDeletion:
-                    description: If true, AND if the owner has the "foregroundDeletion"
-                      finalizer, then the owner cannot be deleted from the key-value
-                      store until this reference is removed. Defaults to false. To
-                      set this field, a user needs "delete" permission of the owner,
-                      otherwise 422 (Unprocessable Entity) will be returned.
-                    type: boolean
-                  controller:
-                    description: If true, this reference points to the managing controller.
-                    type: boolean
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
-                    type: string
-                required:
-                - apiVersion
-                - kind
-                - name
-                - uid
-                type: object
-              type: array
-            resourceVersion:
-              description: "An opaque value that represents the internal version of
-                this object that can be used by clients to determine when objects
-                have changed. May be used for optimistic concurrency, change detection,
-                and the watch operation on a resource or set of resources. Clients
-                must treat these values as opaque and passed unmodified back to the
-                server. They may only be valid for a particular resource or set of
-                resources. \n Populated by the system. Read-only. Value must be treated
-                as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency"
-              type: string
-            selfLink:
-              description: SelfLink is a URL representing this object. Populated by
-                the system. Read-only.
-              type: string
-            uid:
-              description: "UID is the unique in time and space value for this object.
-                It is typically generated by the server on successful creation of
-                a resource and is not allowed to change on PUT operations. \n Populated
-                by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
-              type: string
           type: object
         spec:
+          description: EIPSpec defines the desired state of EIP
           properties:
             assignment:
               description: "Which resource this EIP should be assigned to. \n If not
@@ -427,6 +76,7 @@ spec:
               type: object
           type: object
         status:
+          description: EIPStatus defines the observed state of EIP
           properties:
             allocationId:
               type: string
@@ -444,6 +94,12 @@ spec:
               type: object
             associationId:
               type: string
+            podUUID:
+              description: UID is a type that holds unique ID values, including UUIDs.  Because
+                we don't ONLY use UUIDs, this is an alias to string.  Being a type
+                captures intent and helps make sure that UIDs and names do not get
+                conflated.
+              type: string
             publicIPAddress:
               type: string
             state:
@@ -458,6 +114,7 @@ spec:
           - state
           type: object
       type: object
+  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true

--- a/config/crd/bases/aws.k8s.logmein.com_enis.yaml
+++ b/config/crd/bases/aws.k8s.logmein.com_enis.yaml
@@ -3,6 +3,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: enis.aws.k8s.logmein.com
 spec:
@@ -16,8 +18,10 @@ spec:
   group: aws.k8s.logmein.com
   names:
     kind: ENI
+    listKind: ENIList
     plural: enis
-  scope: ""
+    singular: eni
+  scope: Namespaced
   subresources: {}
   validation:
     openAPIV3Schema:
@@ -26,372 +30,17 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
-          properties:
-            annotations:
-              additionalProperties:
-                type: string
-              description: 'Annotations is an unstructured key value map stored with
-                a resource that may be set by external tools to store and retrieve
-                arbitrary metadata. They are not queryable and should be preserved
-                when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
-              type: object
-            clusterName:
-              description: The name of the cluster which the object belongs to. This
-                is used to distinguish resources with same name and namespace in different
-                clusters. This field is not set anywhere right now and apiserver is
-                going to ignore it if set in create or update request.
-              type: string
-            creationTimestamp:
-              description: "CreationTimestamp is a timestamp representing the server
-                time when this object was created. It is not guaranteed to be set
-                in happens-before order across separate operations. Clients may not
-                set this value. It is represented in RFC3339 form and is in UTC. \n
-                Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-              format: date-time
-              type: string
-            deletionGracePeriodSeconds:
-              description: Number of seconds allowed for this object to gracefully
-                terminate before it will be removed from the system. Only set when
-                deletionTimestamp is also set. May only be shortened. Read-only.
-              format: int64
-              type: integer
-            deletionTimestamp:
-              description: "DeletionTimestamp is RFC 3339 date and time at which this
-                resource will be deleted. This field is set by the server when a graceful
-                deletion is requested by the user, and is not directly settable by
-                a client. The resource is expected to be deleted (no longer visible
-                from resource lists, and not reachable by name) after the time in
-                this field, once the finalizers list is empty. As long as the finalizers
-                list contains items, deletion is blocked. Once the deletionTimestamp
-                is set, this value may not be unset or be set further into the future,
-                although it may be shortened or the resource may be deleted prior
-                to this time. For example, a user may request that a pod is deleted
-                in 30 seconds. The Kubelet will react by sending a graceful termination
-                signal to the containers in the pod. After that 30 seconds, the Kubelet
-                will send a hard termination signal (SIGKILL) to the container and
-                after cleanup, remove the pod from the API. In the presence of network
-                partitions, this object may still exist after this timestamp, until
-                an administrator or automated process can determine the resource is
-                fully terminated. If not set, graceful deletion of the object has
-                not been requested. \n Populated by the system when a graceful deletion
-                is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata"
-              format: date-time
-              type: string
-            finalizers:
-              description: Must be empty before the object is deleted from the registry.
-                Each entry is an identifier for the responsible component that will
-                remove the entry from the list. If the deletionTimestamp of the object
-                is non-nil, entries in this list can only be removed.
-              items:
-                type: string
-              type: array
-            generateName:
-              description: "GenerateName is an optional prefix, used by the server,
-                to generate a unique name ONLY IF the Name field has not been provided.
-                If this field is used, the name returned to the client will be different
-                than the name passed. This value will also be combined with a unique
-                suffix. The provided value has the same validation rules as the Name
-                field, and may be truncated by the length of the suffix required to
-                make the value unique on the server. \n If this field is specified
-                and the generated name exists, the server will NOT return a 409 -
-                instead, it will either return 201 Created or 500 with Reason ServerTimeout
-                indicating a unique name could not be found in the time allotted,
-                and the client should retry (optionally after the time indicated in
-                the Retry-After header). \n Applied only if Name is not specified.
-                More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency"
-              type: string
-            generation:
-              description: A sequence number representing a specific generation of
-                the desired state. Populated by the system. Read-only.
-              format: int64
-              type: integer
-            initializers:
-              description: "An initializer is a controller which enforces some system
-                invariant at object creation time. This field is a list of initializers
-                that have not yet acted on this object. If nil or empty, this object
-                has been completely initialized. Otherwise, the object is considered
-                uninitialized and is hidden (in list/watch and get calls) from clients
-                that haven't explicitly asked to observe uninitialized objects. \n
-                When an object is created, the system will populate this list with
-                the current set of initializers. Only privileged users may set or
-                modify this list. Once it is empty, it may not be modified further
-                by any user. \n DEPRECATED - initializers are an alpha field and will
-                be removed in v1.15."
-              properties:
-                pending:
-                  description: Pending is a list of initializers that must execute
-                    in order before this object is visible. When the last pending
-                    initializer is removed, and no failing result is set, the initializers
-                    struct will be set to nil and the object is considered as initialized
-                    and visible to all clients.
-                  items:
-                    properties:
-                      name:
-                        description: name of the process that is responsible for initializing
-                          this object.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  type: array
-                result:
-                  description: If result is set with the Failure field, the object
-                    will be persisted to storage and then deleted, ensuring that other
-                    clients can observe the deletion.
-                  properties:
-                    apiVersion:
-                      description: 'APIVersion defines the versioned schema of this
-                        representation of an object. Servers should convert recognized
-                        schemas to the latest internal value, and may reject unrecognized
-                        values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-                      type: string
-                    code:
-                      description: Suggested HTTP return code for this status, 0 if
-                        not set.
-                      format: int32
-                      type: integer
-                    details:
-                      description: Extended data associated with the reason.  Each
-                        reason may define its own extended details. This field is
-                        optional and the data returned is not guaranteed to conform
-                        to any schema except that defined by the reason type.
-                      properties:
-                        causes:
-                          description: The Causes array includes more details associated
-                            with the StatusReason failure. Not all StatusReasons may
-                            provide detailed causes.
-                          items:
-                            properties:
-                              field:
-                                description: "The field of the resource that has caused
-                                  this error, as named by its JSON serialization.
-                                  May include dot and postfix notation for nested
-                                  attributes. Arrays are zero-indexed.  Fields may
-                                  appear more than once in an array of causes due
-                                  to fields having multiple errors. Optional. \n Examples:
-                                  \  \"name\" - the field \"name\" on the current
-                                  resource   \"items[0].name\" - the field \"name\"
-                                  on the first array entry in \"items\""
-                                type: string
-                              message:
-                                description: A human-readable description of the cause
-                                  of the error.  This field may be presented as-is
-                                  to a reader.
-                                type: string
-                              reason:
-                                description: A machine-readable description of the
-                                  cause of the error. If this value is empty there
-                                  is no information available.
-                                type: string
-                            type: object
-                          type: array
-                        group:
-                          description: The group attribute of the resource associated
-                            with the status StatusReason.
-                          type: string
-                        kind:
-                          description: 'The kind attribute of the resource associated
-                            with the status StatusReason. On some operations may differ
-                            from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-                          type: string
-                        name:
-                          description: The name attribute of the resource associated
-                            with the status StatusReason (when there is a single name
-                            which can be described).
-                          type: string
-                        retryAfterSeconds:
-                          description: If specified, the time in seconds before the
-                            operation should be retried. Some errors may indicate
-                            the client must take an alternate action - for those errors
-                            this field may indicate how long to wait before taking
-                            the alternate action.
-                          format: int32
-                          type: integer
-                        uid:
-                          description: 'UID of the resource. (when there is a single
-                            resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
-                          type: string
-                      type: object
-                    kind:
-                      description: 'Kind is a string value representing the REST resource
-                        this object represents. Servers may infer this from the endpoint
-                        the client submits requests to. Cannot be updated. In CamelCase.
-                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-                      type: string
-                    message:
-                      description: A human-readable description of the status of this
-                        operation.
-                      type: string
-                    metadata:
-                      description: 'Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-                      properties:
-                        continue:
-                          description: continue may be set if the user set a limit
-                            on the number of items returned, and indicates that the
-                            server has more data available. The value is opaque and
-                            may be used to issue another request to the endpoint that
-                            served this list to retrieve the next set of available
-                            objects. Continuing a consistent list may not be possible
-                            if the server configuration has changed or more than a
-                            few minutes have passed. The resourceVersion field returned
-                            when using this continue value will be identical to the
-                            value in the first response, unless you have received
-                            this token from an error message.
-                          type: string
-                        resourceVersion:
-                          description: 'String that identifies the server''s internal
-                            version of this object that can be used by clients to
-                            determine when objects have changed. Value must be treated
-                            as opaque by clients and passed unmodified back to the
-                            server. Populated by the system. Read-only. More info:
-                            https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
-                          type: string
-                        selfLink:
-                          description: selfLink is a URL representing this object.
-                            Populated by the system. Read-only.
-                          type: string
-                      type: object
-                    reason:
-                      description: A machine-readable description of why this operation
-                        is in the "Failure" status. If this value is empty there is
-                        no information available. A Reason clarifies an HTTP status
-                        code but does not override it.
-                      type: string
-                    status:
-                      description: 'Status of the operation. One of: "Success" or
-                        "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
-                      type: string
-                  type: object
-              required:
-              - pending
-              type: object
-            labels:
-              additionalProperties:
-                type: string
-              description: 'Map of string keys and values that can be used to organize
-                and categorize (scope and select) objects. May match selectors of
-                replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
-              type: object
-            managedFields:
-              description: "ManagedFields maps workflow-id and version to the set
-                of fields that are managed by that workflow. This is mostly for internal
-                housekeeping, and users typically shouldn't need to set or understand
-                this field. A workflow can be the user's name, a controller's name,
-                or the name of a specific apply path like \"ci-cd\". The set of fields
-                is always in the version that the workflow used when modifying the
-                object. \n This field is alpha and can be changed or removed without
-                notice."
-              items:
-                properties:
-                  apiVersion:
-                    description: APIVersion defines the version of this resource that
-                      this field set applies to. The format is "group/version" just
-                      like the top-level APIVersion field. It is necessary to track
-                      the version of a field set because it cannot be automatically
-                      converted.
-                    type: string
-                  fields:
-                    additionalProperties: true
-                    description: Fields identifies a set of fields.
-                    type: object
-                  manager:
-                    description: Manager is an identifier of the workflow managing
-                      these fields.
-                    type: string
-                  operation:
-                    description: Operation is the type of operation which lead to
-                      this ManagedFieldsEntry being created. The only valid values
-                      for this field are 'Apply' and 'Update'.
-                    type: string
-                  time:
-                    description: Time is timestamp of when these fields were set.
-                      It should always be empty if Operation is 'Apply'
-                    format: date-time
-                    type: string
-                type: object
-              type: array
-            name:
-              description: 'Name must be unique within a namespace. Is required when
-                creating resources, although some resources may allow a client to
-                request the generation of an appropriate name automatically. Name
-                is primarily intended for creation idempotence and configuration definition.
-                Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-              type: string
-            namespace:
-              description: "Namespace defines the space within each name must be unique.
-                An empty namespace is equivalent to the \"default\" namespace, but
-                \"default\" is the canonical representation. Not all objects are required
-                to be scoped to a namespace - the value of this field for those objects
-                will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info:
-                http://kubernetes.io/docs/user-guide/namespaces"
-              type: string
-            ownerReferences:
-              description: List of objects depended by this object. If ALL objects
-                in the list have been deleted, this object will be garbage collected.
-                If this object is managed by a controller, then an entry in this list
-                will point to this controller, with the controller field set to true.
-                There cannot be more than one managing controller.
-              items:
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  blockOwnerDeletion:
-                    description: If true, AND if the owner has the "foregroundDeletion"
-                      finalizer, then the owner cannot be deleted from the key-value
-                      store until this reference is removed. Defaults to false. To
-                      set this field, a user needs "delete" permission of the owner,
-                      otherwise 422 (Unprocessable Entity) will be returned.
-                    type: boolean
-                  controller:
-                    description: If true, this reference points to the managing controller.
-                    type: boolean
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
-                    type: string
-                required:
-                - apiVersion
-                - kind
-                - name
-                - uid
-                type: object
-              type: array
-            resourceVersion:
-              description: "An opaque value that represents the internal version of
-                this object that can be used by clients to determine when objects
-                have changed. May be used for optimistic concurrency, change detection,
-                and the watch operation on a resource or set of resources. Clients
-                must treat these values as opaque and passed unmodified back to the
-                server. They may only be valid for a particular resource or set of
-                resources. \n Populated by the system. Read-only. Value must be treated
-                as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency"
-              type: string
-            selfLink:
-              description: SelfLink is a URL representing this object. Populated by
-                the system. Read-only.
-              type: string
-            uid:
-              description: "UID is the unique in time and space value for this object.
-                It is typically generated by the server on successful creation of
-                a resource and is not allowed to change on PUT operations. \n Populated
-                by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
-              type: string
           type: object
         spec:
+          description: ENISpec defines the desired state of an ElasticNetworkInterface
           properties:
             attachment:
               properties:
@@ -411,10 +60,11 @@ spec:
             subnetID:
               type: string
           required:
-          - subnetID
           - securityGroups
+          - subnetID
           type: object
         status:
+          description: ENIStatus defines the observed state of ENI
           properties:
             attachment:
               properties:
@@ -422,6 +72,8 @@ spec:
                   minLength: 0
                   type: string
               type: object
+            macAddress:
+              type: string
             networkInterfaceID:
               type: string
             privateIPAddresses:
@@ -429,9 +81,11 @@ spec:
                 type: string
               type: array
           required:
+          - macAddress
           - networkInterfaceID
           type: object
       type: object
+  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -11,38 +11,58 @@ rules:
   resources:
   - eips
   verbs:
+  - create
+  - delete
   - get
   - list
-  - watch
-  - create
-  - update
   - patch
-  - delete
+  - update
+  - watch
 - apiGroups:
   - aws.k8s.logmein.com
   resources:
   - eips/status
   verbs:
   - get
-  - update
   - patch
+  - update
 - apiGroups:
   - aws.k8s.logmein.com
   resources:
   - enis
   verbs:
+  - create
+  - delete
   - get
   - list
-  - watch
-  - create
-  - update
   - patch
-  - delete
+  - update
+  - watch
 - apiGroups:
   - aws.k8s.logmein.com
   resources:
   - enis/status
   verbs:
   - get
-  - update
   - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/controllers/pod_controller.go
+++ b/controllers/pod_controller.go
@@ -1,0 +1,78 @@
+/*
+
+Copyright 2020 LogMeIn Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+package controllers
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	awsv1alpha1 "github.com/logmein/k8s-aws-operator/api/v1alpha1"
+)
+
+// PodReconciler reconciles a Pod object
+type PodReconciler struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;update;patch
+
+func (r *PodReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	ctx := context.Background()
+	_ = r.Log.WithValues("pod", req.NamespacedName)
+
+	pod := corev1.Pod{}
+	if err := r.Get(ctx, req.NamespacedName, &pod); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	eips := &awsv1alpha1.EIPList{}
+	if err := r.List(ctx, eips); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	for _, eip := range eips.Items {
+		if eip.Status.Assignment != nil && eip.Status.Assignment.PodName == pod.Name && eip.Status.PodUID == pod.UID {
+			// pod UID doesn't match anymore -> pod was replaced; reset podUID and let the EIP controller do the rest
+			eip.Status.PodUID = types.UID("")
+			return ctrl.Result{}, r.Status().Update(ctx, &eip)
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Pod{}).
+		Complete(r)
+}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	awsv1alpha1 "github.com/logmein/k8s-aws-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,6 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	awsv1alpha1 "github.com/logmein/k8s-aws-operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -61,6 +63,9 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(cfg).ToNot(BeNil())
 
 	err = awsv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = corev1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme

--- a/main.go
+++ b/main.go
@@ -23,13 +23,14 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	awsv1alpha1 "github.com/logmein/k8s-aws-operator/api/v1alpha1"
-	"github.com/logmein/k8s-aws-operator/controllers"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	awsv1alpha1 "github.com/logmein/k8s-aws-operator/api/v1alpha1"
+	"github.com/logmein/k8s-aws-operator/controllers"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -41,6 +42,7 @@ var (
 func init() {
 	corev1.AddToScheme(scheme)
 	awsv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }
 
@@ -100,6 +102,14 @@ func main() {
 	}).SetupWithManager(mgr)
 	if err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ENI")
+		os.Exit(1)
+	}
+	if err = (&controllers.PodReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("Pod"),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Pod")
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder


### PR DESCRIPTION
Pod UID is saved in the status field of the EIP resource to distinguish
different pods with the same name.

Fixes #9.