### PR TITLE
feat: add recommended labels to the Helm Chart

### DIFF
--- a/charts/k8s-aws-operator/templates/_helpers.tpl
+++ b/charts/k8s-aws-operator/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "k8s-aws-operator.name" -}}
+{{- default .Chart.Name .Values.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "k8s-aws-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.name }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "k8s-aws-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "k8s-aws-operator.labels" -}}
+helm.sh/chart: {{ include "k8s-aws-operator.chart" . }}
+{{ include "k8s-aws-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ default .Chart.AppVersion .Values.image.tag | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "k8s-aws-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+{{- end }}

--- a/charts/k8s-aws-operator/templates/deployment.yaml
+++ b/charts/k8s-aws-operator/templates/deployment.yaml
@@ -1,18 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ include "k8s-aws-operator.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ .Chart.Name }}
+    {{- include "k8s-aws-operator.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Chart.Name }}
+      {{- include "k8s-aws-operator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ .Chart.Name }}
+        {{- include "k8s-aws-operator.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Chart.Name }}
       {{- with .Values.nodeSelector }}

--- a/charts/k8s-aws-operator/templates/rbac.yaml
+++ b/charts/k8s-aws-operator/templates/rbac.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ include "k8s-aws-operator.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ .Chart.Name }}
+    {{- include "k8s-aws-operator.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{ . | toYaml | nindent 4 }}
@@ -13,9 +13,9 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ include "k8s-aws-operator.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ .Chart.Name }}
+    {{- include "k8s-aws-operator.labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -27,9 +27,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ include "k8s-aws-operator.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ .Chart.Name }}
+    {{- include "k8s-aws-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -44,9 +44,9 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ include "k8s-aws-operator.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ .Chart.Name }}
+    {{- include "k8s-aws-operator.labels" . | nindent 4 }}
 rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
@@ -62,9 +62,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ include "k8s-aws-operator.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ .Chart.Name }}
+    {{- include "k8s-aws-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/k8s-aws-operator/templates/service.yaml
+++ b/charts/k8s-aws-operator/templates/service.yaml
@@ -1,10 +1,10 @@
-{{- if .Values.metrics.serviceMonitor.enable }}
+{{- if .Values.metrics.serviceMonitor.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Chart.Name }}-metrics
+  name: {{ include "k8s-aws-operator.fullname" . }}-metrics
   labels:
-    app.kubernetes.io/name: {{ .Chart.Name }}
+    {{- include "k8s-aws-operator.labels" . | nindent 4 }}
 spec:
   {{- with .Values.metrics.service.clusterIP }}
   clusterIP: {{ . | quote }}
@@ -15,5 +15,5 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    app.kubernetes.io/name: {{ .Chart.Name }}
+    {{- include "k8s-aws-operator.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/k8s-aws-operator/templates/servicemonitor.yaml
+++ b/charts/k8s-aws-operator/templates/servicemonitor.yaml
@@ -2,13 +2,13 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ include "k8s-aws-operator.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ .Chart.Name }}
+    {{- include "k8s-aws-operator.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Chart.Name }}
+      {{- include "k8s-aws-operator.selectorLabels" . | nindent 6 }}
   endpoints:
   {{- with .Values.metrics.serviceMonitor.endpoints }}
   {{ . | toYaml | nindent 2 }}


### PR DESCRIPTION
This adds the following [recommended Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) to resources generated by the Helm Chart:

```yaml
helm.sh/chart: k8s-aws-operator-<chart version>
app.kubernetes.io/name: k8s-aws-operator
app.kubernetes.io/instance: <release name>
app.kubernetes.io/version: "<app version>"
app.kubernetes.io/managed-by: Helm
```

**Hint:** It also adds the `app.kubernetes.io/instance: <release name>` label to all selectors. [These selectors are immutable](https://handbook.giantswarm.io/docs/dev-and-releng/app-developer-processes/matchlabels-are-immutable/) and therefore it is not possible to do an usual update.