### PR TITLE
feat: allow deployment annotations in Helm Chart

### DIFF
--- a/charts/k8s-aws-operator/templates/deployment.yaml
+++ b/charts/k8s-aws-operator/templates/deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "k8s-aws-operator.fullname" . }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "k8s-aws-operator.labels" . | nindent 4 }}
 spec:

--- a/charts/k8s-aws-operator/values.yaml
+++ b/charts/k8s-aws-operator/values.yaml
@@ -3,6 +3,8 @@ image:
   repository: goto-opensource/k8s-aws-operator
   tag: # coming from appVersion
 
+# deploymentAnnotations: {}
+
 resources:
   requests:
     cpu: 20m


### PR DESCRIPTION
As a user of the Helm Chart, you can now set annotations for the Deployment resource via `deploymentAnnotations: {}` value.